### PR TITLE
[Common] 상품 태그 공통 컴포넌트

### DIFF
--- a/src/components/common/ProductTag.tsx
+++ b/src/components/common/ProductTag.tsx
@@ -1,0 +1,68 @@
+import styled from 'styled-components';
+
+interface ProductTagContainerProps {
+  width: number;
+  color: string;
+  children: string;
+}
+
+interface ProductTagProps {
+  children: string;
+}
+
+const ProductTag = (props: ProductTagProps) => {
+  const { children } = props;
+  let width, color;
+
+  switch (children) {
+    case 'BEST':
+      width = 3.6;
+      color = 'pink_100';
+      break;
+
+    case '단독':
+      width = 3;
+      color = 'green_300';
+      break;
+
+    case '오늘드림':
+      width = 4.6;
+      color = 'sky_300';
+      break;
+
+    case '증정':
+      width = 3;
+      color = 'red_300';
+      break;
+
+    default:
+      width = 3.6;
+      color = 'pink_100';
+      break;
+  }
+
+  return (
+    <St.ProductTagContainer width={width} color={color}>
+      {children}
+    </St.ProductTagContainer>
+  );
+};
+
+export default ProductTag;
+
+const St = {
+  ProductTagContainer: styled.span<ProductTagContainerProps>`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    width: ${(props) => props.width + 'rem;'};
+    height: 1.6rem;
+
+    border-radius: 0.8rem;
+    background-color: ${({ theme, color }) => theme.colors[color]};
+
+    color: ${({ theme }) => theme.colors.gray_000};
+    ${({ theme }) => theme.fonts.Body1};
+  `,
+};

--- a/src/components/common/ProductTag.tsx
+++ b/src/components/common/ProductTag.tsx
@@ -6,7 +6,8 @@ interface ProductTagProps {
 
 const ProductTag = (props: ProductTagProps) => {
   const { children } = props;
-  let width, color;
+  let width = 0,
+    color = '';
 
   switch (children) {
     case 'BEST':

--- a/src/components/common/ProductTag.tsx
+++ b/src/components/common/ProductTag.tsx
@@ -1,11 +1,5 @@
 import styled from 'styled-components';
 
-interface ProductTagContainerProps {
-  width: number;
-  color: string;
-  children: string;
-}
-
 interface ProductTagProps {
   children: string;
 }
@@ -49,7 +43,7 @@ const ProductTag = (props: ProductTagProps) => {
 export default ProductTag;
 
 const St = {
-  ProductTagContainer: styled.span<ProductTagContainerProps>`
+  ProductTagContainer: styled.span<{ width: number; color: string }>`
     display: flex;
     justify-content: center;
     align-items: center;

--- a/src/components/common/ProductTag.tsx
+++ b/src/components/common/ProductTag.tsx
@@ -49,7 +49,7 @@ const St = {
     justify-content: center;
     align-items: center;
 
-    width: ${(props) => props.width + 'rem;'};
+    width: ${({ width }) => width + 'rem;'};
     height: 1.6rem;
 
     border-radius: 0.8rem;

--- a/src/components/common/ProductTag.tsx
+++ b/src/components/common/ProductTag.tsx
@@ -36,8 +36,6 @@ const ProductTag = (props: ProductTagProps) => {
       break;
 
     default:
-      width = 3.6;
-      color = 'pink_100';
       break;
   }
 

--- a/src/styles/style.d.ts
+++ b/src/styles/style.d.ts
@@ -3,6 +3,7 @@ import 'styled-components';
 declare module 'styled-components' {
   export interface DefaultTheme {
     colors: {
+      [key: string]: string;
       gray_900: string;
       gray_700: string;
       gray_500: string;


### PR DESCRIPTION
## 🔥 Related Issues
- close #3

## 💙 작업 내용
- [x] 상품 태그 공통 컴포넌트 구현 

## ✅ PR Point
![image](https://github.com/GOSOPT-CDS-TEAM2/frontend/assets/55528304/ec18af98-f32f-46ea-b4dd-525406c34074)
- 상품 아래에 들어가는 BEST, 단독, 오늘드림, 증정 태그에 해당하는 공통 컴포넌트를 제작했습니다.
- children으로 해당하는 태그 이름을 적으면 switch문으로 태그의 width와 color를 지정하여 스타일링합니다.

## 😡 Trouble Shooting
받아온 children에 따라 색을 다르게 해야해서, styled-component에서 ${({theme})=>theme.colors.{변수}}와 같은 식을 사용해야했는데 자꾸만 오류가 났다... 알아보니 객체의 key를 가지고 value에 접근할 때 점표기법으로 접근하면 변수를 사용할 수 없다고 한다! 따라서 점표기법이 아닌 괄호 표기법을 통해 ${({theme})=>theme.colors[변수]} 이런식으로 접근할 수 있었다!

## 👀 스크린샷 / GIF / 링크
다음과 같이 사용합니다.
```javascript
<>
  <ProductTag>BEST</ProductTag>
  <ProductTag>단독</ProductTag>
  <ProductTag>오늘드림</ProductTag>
  <ProductTag>증정</ProductTag>
</>
```

<img width="815" alt="image" src="https://github.com/GOSOPT-CDS-TEAM2/frontend/assets/55528304/e4d28243-03de-4bac-aab2-4c81584f4409">


## 📚 Reference
- https://itchallenger.tistory.com/394
- [https://velog.io/@ktg6360/TIL-015-점표기법Dot-Notation-vs-괄호표기법Bracket-Notation](https://velog.io/@ktg6360/TIL-015-%EC%A0%90%ED%91%9C%EA%B8%B0%EB%B2%95Dot-Notation-vs-%EA%B4%84%ED%98%B8%ED%91%9C%EA%B8%B0%EB%B2%95Bracket-Notation)
- https://victory-ju.tistory.com/entry/React-Styled-Component-%EC%82%AC%EC%9A%A9%ED%95%B4%EB%B3%B4%EA%B8%B0-Props%EB%A1%9C-%EC%9E%AC%EC%82%AC%EC%9A%A9-%EC%BB%B4%ED%8F%AC%EB%84%8C%ED%8A%B8-%EB%A7%8C%EB%93%A4%EA%B8%B0
